### PR TITLE
Specify dependency on logger

### DIFF
--- a/slack-ruby-client.gemspec
+++ b/slack-ruby-client.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday-multipart'
   s.add_dependency 'gli'
   s.add_dependency 'hashie'
+  s.add_dependency 'logger'
   s.metadata['rubygems_mfa_required'] = 'true'
   s.metadata['changelog_uri'] = 'https://github.com/slack-ruby/slack-ruby-client/blob/master/CHANGELOG.md'
 end


### PR DESCRIPTION
It's moving from the stdlib to a gem in ruby 3.5:
https://github.com/ruby/ruby/commit/cda268d8e99170f73c9c0c7dd2dbe9494ba89abb
